### PR TITLE
Fix bootstraping caching

### DIFF
--- a/knowledge_gpt/core/caching.py
+++ b/knowledge_gpt/core/caching.py
@@ -12,7 +12,7 @@ def file_hash_func(file: File) -> str:
     return file.id
 
 
-@st.cache_resource()
+@st.cache_data(show_spinner=False)
 def bootstrap_caching():
     """Patch module functions with caching"""
 


### PR DESCRIPTION
Using `cache_resource()` causes some unexpected bugs and often results in cache misses.